### PR TITLE
Fixes ControllerHelpers#node_rails_devise_redis_sync to use passed current_user instead of instance variable

### DIFF
--- a/lib/node-rails/controller_helpers.rb
+++ b/lib/node-rails/controller_helpers.rb
@@ -4,7 +4,7 @@ module NodeRails
       #store session to redis
       if current_user
         # an unique MD5 key
-        cookies["_validation_token_key"] = Digest::MD5.hexdigest("#{session[:session_id]}:#{@current_user.id}")
+        cookies["_validation_token_key"] = Digest::MD5.hexdigest("#{session[:session_id]}:#{current_user.id}")
         # store session data or any authentication data you want here, generate to JSON data
         stored_session = JSON.generate({"user_id"=> current_user.id})
         $redis.hset(


### PR DESCRIPTION
Use of @current_user seems to be typo. It forces to declare @current_user in controller methods that use this module method, which is unnecessary since current_user is already passed in as an argument. 
